### PR TITLE
cache component styles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,7 @@ export default function withStyles(css) {
 
       componentWillUnmount() {
         let refs = cache.get(DecoratedComponent);
-        refs.count--;
-        if (refs.count === 0) {
+        if (--refs.count === 0) {
             cache.delete(DecoratedComponent)
             removeStyle(this.elm);
             this.elm = null;


### PR DESCRIPTION
This creates a map where each DecoratedComponent serves as unique symbol. References are counted and styles are only mounted/unmounted if refs are zero.

Fixes #4 
