### PR TITLE
Transform runtime removes es6 requirement at runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react", "stage-0"]
+  "presets": ["es2015", "react", "stage-0"],
+  "plugins": ["transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-cli": "^6.11.4",
     "babel-core": "^6.11.4",
     "babel-eslint": "^6.1.2",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
Without runtime an es6 Map makes it into the compiled lib. Forcing consumers of the library to need an es6 polyfill. Closes #7 
