### PR TITLE
Fix eslint-config-airbnb peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "csjs": "^1.0.5",
     "eslint": "^3.1.1",
     "eslint-config-airbnb": "^12.0.0",
-    "eslint-plugin-import": "^2.0.1",
+    "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^6.4.1",
     "jsdom": "^9.6.0",


### PR DESCRIPTION
eslint-config-airbnb@12.0.0 wants eslint-plugin-import@^1.16.0

Fixes #18.
