### PR TITLE
Add Coveralls badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 React Higher Order Component for [CSJS](https://github.com/rtsao/csjs). Automatically mounts/unmounts styles, works with React Hot Loader. _Inspired by the JSS-equivalent, [react-jss](https://github.com/jsstyles/react-jss)._
 
-[![npm](https://img.shields.io/npm/v/react-csjs.svg)](https://www.npmjs.com/package/react-csjs) [![Build Status](https://travis-ci.org/tizmagik/react-csjs.svg?branch=master)](https://travis-ci.org/tizmagik/react-csjs)
+[![npm](https://img.shields.io/npm/v/react-csjs.svg)](https://www.npmjs.com/package/react-csjs)
+[![Build Status](https://travis-ci.org/tizmagik/react-csjs.svg?branch=master)](https://travis-ci.org/tizmagik/react-csjs)
+[![Coverage Status](https://coveralls.io/repos/github/tizmagik/react-csjs/badge.svg)](https://coveralls.io/github/tizmagik/react-csjs)
 
 ### Auto-mount/unmounting of styles
 


### PR DESCRIPTION
@tizmagik 

I enabled the project in [Coveralls](https://coveralls.io/github/tizmagik/react-csjs). Coverage reports were already being piped there as of b9a7ac2ab86873457e2a29230748c4d48dbe65a3, so we should be good. Feel free to disable their commenting if you find it intrusive (it can get a bit chatty).
