### PR TITLE
added original props attribute to the returned decorated class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export default function (userCss, ...values) {
       }
 
       render() {
-        return <DecoratedComponent classes={css} {...this.props} />;
+        return <DecoratedComponent classes={css} oprops={this.props} {...this.props} />;
       }
     };
 }


### PR DESCRIPTION
... Spread operator override child component 'classes' (Solution: pass original props attribute)

Hello again, I have came across this issue frequently. basically when using the spread operator. 'classes' attribute gets overridden on a child component, and sometimes the child component doesn't even have propType for classes which throws an error. See the example below, 

``` javascript
const style = csjs`
`
const Parent = (props) => (
      <Child {...props} />
    );

export default withStyle(style)(Parent)
```
basically the child 'classes' attribute always get overridden by the empty style in the parent component. An easy fix can be adding 'oprops' or 'original props' to the returned decorated component 

``` javascript
      
// oprops is the original props
render() {
   return <DecoratedComponent classes={css} oprops={this.props} {...this.props} />;
}
```

And now you can easily have composition with this 

``` javascript
const style = csjs`
`
const Parent = ({ oprops, classes }) => (
      <Child {...oprops} />
    );

export default withStyle(style)(Parent)
``` 

I hope you like the suggestion as it should make composition much easier. Thanks 