### PR TITLE
Add test for tagged decorator syntax

### DIFF
--- a/test/components/DecoratedButton.js
+++ b/test/components/DecoratedButton.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { testStyles } from '../testUtil';
+import withStyles from '../../src';
+
+// Decorator Syntax
+@withStyles(testStyles)
+export default class extends React.Component {
+  render() {
+    return (
+      <div className={this.props.classes.button}>
+        <span className={this.props.classes.label}>
+          {this.props.children}
+        </span>
+      </div>
+    );
+  }
+}

--- a/test/components/TaggedDecoratedButton.js
+++ b/test/components/TaggedDecoratedButton.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { testCss } from '../testUtil';
+import csjs from '../../src';
+
+// Tagged Decorator Syntax
+@csjs`${testCss}`
+export default class extends React.Component {
+  render() {
+    return (
+      <div className={this.props.classes.button}>
+        <span className={this.props.classes.label}>
+          {this.props.children}
+        </span>
+      </div>
+    );
+  }
+}

--- a/test/components/WrappedButton.js
+++ b/test/components/WrappedButton.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { testStyles } from '../testUtil';
+import withStyles from '../../src';
+
+// Wrapped Syntax
+const ButtonComponent = ({ classes, children }) => (
+  <div className={classes.button}>
+    <span className={classes.label}>
+      {children}
+    </span>
+  </div>
+);
+
+export default withStyles(testStyles)(ButtonComponent);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,9 +5,10 @@ import sinon from 'sinon';
 import {
   testElm,
   testStyles,
-  DecoratedButton,
-  WrappedButton,
 } from './testUtil';
+import TaggedDecoratedButton from './components/TaggedDecoratedButton';
+import DecoratedButton from './components/DecoratedButton';
+import WrappedButton from './components/WrappedButton';
 import withStyles from '../src';
 
 describe('index.js', () => {
@@ -30,6 +31,16 @@ describe('index.js', () => {
   });
 
   describe('withStyles', () => {
+    it('should return a styled React component (tagged decorator)', () => {
+      const wrapper = shallow(<TaggedDecoratedButton />);
+      expect(wrapper.props().classes).to.be.an.instanceOf(Object);
+      Object
+        .keys(testStyles)
+        .forEach((style) => {
+          expect(wrapper.html()).to.contain(testStyles[`${style}`].className);
+        });
+    });
+
     it('should return a styled React component (decorator)', () => {
       const wrapper = shallow(<DecoratedButton />);
       expect(wrapper.props().classes).to.be.an.instanceOf(Object);

--- a/test/testUtil.js
+++ b/test/testUtil.js
@@ -1,7 +1,5 @@
-import React from 'react';
 import csjs from 'csjs';
 import { jsdom } from 'jsdom';
-import withStyles from '../src';
 
 export const testCss = `
   .button {
@@ -14,31 +12,6 @@ export const testCss = `
 `;
 
 export const testStyles = csjs`${testCss}`;
-
-// Decorator Syntax
-@withStyles(testStyles)
-export class DecoratedButton extends React.Component {
-  render() {
-    return (
-      <div className={this.props.classes.button}>
-        <span className={this.props.classes.label}>
-          {this.props.children}
-        </span>
-      </div>
-    );
-  }
-}
-
-// Wrapped Syntax
-export const ButtonComponent = ({ classes, children }) => (
-  <div className={classes.button}>
-    <span className={classes.label}>
-      {children}
-    </span>
-  </div>
-);
-
-export const WrappedButton = withStyles(testStyles)(ButtonComponent);
 
 export const testElm = jsdom().createElement('style');
 testElm.setAttribute('type', 'text/css');


### PR DESCRIPTION
Also broke test components out into their own files. `testUtil` was getting a bit cluttered.

Closes #17.