### PR TITLE
Fix and reorganize certain tests

### DIFF
--- a/test/insert-style.test.js
+++ b/test/insert-style.test.js
@@ -4,6 +4,12 @@ import { expect } from 'chai';
 const cacheKey = require.resolve('../src/insert-style');
 
 describe('insert-style', () => {
+  const document = global.document;
+
+  after(() => {
+    global.document = document;
+  });
+
   beforeEach(() => {
     if (require.cache[cacheKey]) {
       delete require.cache[cacheKey];
@@ -16,12 +22,12 @@ describe('insert-style', () => {
       const insertStyle = require('../src/insert-style');
 
       expect(insertStyle.__get__('isServer')).to.equal(false);
-      delete global.document;
     });
   });
 
   describe('when on the server', () => {
     it('should return Server variant', () => {
+      delete global.document;
       const insertStyle = require('../src/insert-style');
 
       expect(insertStyle.__get__('isServer')).to.equal(true);

--- a/test/insertStyle.test.js
+++ b/test/insertStyle.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 const cacheKey = require.resolve('../src/insert-style');
 
-describe('insert-style', () => {
+describe('insertStyle', () => {
   const document = global.document;
 
   after(() => {


### PR DESCRIPTION
* Prevent insertStyle tests from trampling global.document
* Rename test files to match functions tested rather than filenames
* Reorganize withStyles tests into clearer groupings